### PR TITLE
remove again sdcardfs

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -164,10 +164,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qc.sensors.wl_dis=true \
     ro.qualcomm.sensors.smd=true
 
-# Storage
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sys.sdcardfs=true
-
 # Telephony
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.radio.noril=1


### PR DESCRIPTION
Removing sdcardfs (thus using good old fuse instead) solves a bug / modified behaviour
to be described below. There should be a better way to achieve the same goal with sdcardfs.

Apparently, sdcardfs breaks transparent bind mounts. In a terminal app, run e.g.

v500:/ $ su
v500:/ # cd data/media/0
v500:/data/media/0 # cd Documents/
v500:/data/media/0/Documents # mkdir tmp
v500:/data/media/0/Documents # mkdir tmp2
v500:/data/media/0/Documents # busybox mount --bind tmp tmp2
v500:/data/media/0/Documents # cd tmp
v500:/data/media/0/Documents/tmp # >test1
v500:/data/media/0/Documents/tmp # cd ../tmp2
v500:/data/media/0/Documents/tmp2 # >test2
v500:/data/media/0/Documents/tmp2 # ls
test1 test2
v500:/data/media/0/Documents/tmp2 # ls ../tmp
test1 test2

With sdcardfs enabled, any Android app sees the files test1 and test2
in the /sdcard/Documents/tmp directory, while the /sdcard/Documents/tmp2
directory appears empty to Android apps(!)

With sdcardfs disabled, Android apps see the two files in either directory,
which is the behaviour I expect.